### PR TITLE
Add beginning KoP page

### DIFF
--- a/_tech/kit_of_parts.md
+++ b/_tech/kit_of_parts.md
@@ -8,9 +8,60 @@ The Kit of parts is the set of parts, tools, documents, and software given to ea
 
 ## Motors
 
+| Item           | Part Number   | Qty | Rookie Tote? |
+| -------------- | ------------- | --- | ------------ |
+| Throttle Motor | AE235100-0160 | 4   | No           |
+| Window  Motor  | 5-163800-RC1  | 2   | No           |
+| BAG Motor      | 217-3351      | 1   | No           |
+| CIM Motor      | 217-2000      | 4   | No           |
+| MiniCIM Motor  | 217-3371      | 1   | No           |
+
+NOTE: 2 CIMs were in the VexPro Donation Kit, 2 were just loose in the tote.
+
 ## Pneumatics
 
+| Item                   | Part Number                       | Qty | Rookie Tote? |
+| ---------------------- | --------------------------------- | --- | ------------ |
+| Plug Socket with Cable | NEBV-H1G2-KN-0.5- N-LE2 or 566654 | 2   | Only         |
+| Electrical sub-base    | VAVE-L1-1H2-LR or 566716          | 2   | Only         |
+| M7 Fitting, 1/4 in     | VAVE-L1-1H2-LR or 566716          | 3   | Only         |
+| 24V Double Solenoid    | VUVG-L10-B52-T-M7- 1P3 or 556475  | 1   | Only         |
+| PTFE Thread Seal Tape  | N/A                               | 1   | Only         |
+| Pressure Gauge         | 18-013-212                        | 2   | Only         |
+| Pressure Regulator     | R07-100-RNEA                      | 1   | Only         |
+| Regulator Mounting Kit | 18-025-003                        | 1   | Only         |
+| Relief Valve           | 16-004-011                        | 1   | Only         |
+| Pressure Switch        | SM-2B-115R/443                    | 1   | Only         |
+| Micro Valve            | MV709-2                           | 1   | Only         |
+| Union Tee              | 2203P-2                           | 3   | Only         |
+| 1/4 in to 1/8 Adapter  | 229-4-2                           | 1   | Only         |
+| 1/4 in to 1/8 Bushing  | 209P-4-2                          | 2   | Only         |
+| Press Fit Connector    | W68PLP-4-2                        | 6   | Only         |
+| Press Fit Elbow        | W369PLP-4-2                       | 4   | Only         |
+| Press Fit Tee          | 364PLP-4                          | 2   | Only         |
+| 1/8 in Plug            | 218P-2                            | 2   | Only         |
+| 1/8 in Hex Nipple      | 216P-2                            | 3   | Only         |
+| 1/4 in Plug            | 218P-4                            | 2   | Only         |
+| 5 in stroke, 3/4 bore Piston | NCDMB075-0500C              | 1   | Only         |
+| 32 in^3 Air Tank       | AVT-PP-35                         | 1   | Only         |
+| Polyurethane Tubing    | FIRST-BAG-01                      | 1   | Only         |
+| Vlair 90C Compressor   | 00090                             | 1   | Only         |
+
 ## Control System
+
+| Item                | Part Number             | Qty | Rookie Tote? |
+| ------------------- | ----------------------- | --- | ------------ |
+| Robot Radio         | OM5P-AN                 | 1   | No           |
+| USB Image Drive     | N/A                     | 1   | Only         |
+| Acer Netbook        | ES1-111M-P2YU           | 1   | Only         |
+| PCM                 | 14-806777 or CTRE_PCM_1 | 1   | Only         |
+| PDP                 | 14-806880 or CTRE_PDP_1 | 1   | Only         |
+| VRM                 | 14-868277 or CTRE_VRM_1 | 1   | Only         |
+| 5LP Prototyping Kit | CY8CKIT-059             | 1   | Only         |
+| Joystick            | 963290-0403             | 1   | Only         |
+| Victor SP           | 217-9090                | 2   | Only         |
+| Xbox 360 Controller | X18-93977-01            | 1   | Only         |
+| NI roboRIO          | 155213D-01L             | 1   | Only         |
 
 ## Electronics
 


### PR DESCRIPTION
Still needs electronics, structural, drive train, and software sections. Will need to go back and add links to each product's page later. Also renders weirdly locally, hoping looks better on server.
