### PR TITLE
Update the OpenRIO entry

### DIFF
--- a/_tech/programming/unofficial/openrio.md
+++ b/_tech/programming/unofficial/openrio.md
@@ -8,8 +8,6 @@ project:
   sourcecode: https://github.com/Open-RIO
 ---
 
-{% include stub %}
-
 [OpenRIO](https://github.com/Open-RIO) is an open source, collaborative organisation that provides APIs, Frameworks, Examples and other Software Utilities for FRC teams and members around the world. The organisation is best known for its work on the [Toast API](https://github.com/Open-RIO/ToastAPI) and [GradleRIO](https://github.com/Open-RIO/GradleRIO). Although in the early years of OpenRIO the Java programming language was primarily used, other languages such as C and C++ have also gained traction in future and existing projects.
 
 ## Mission Statement

--- a/_tech/programming/unofficial/openrio.md
+++ b/_tech/programming/unofficial/openrio.md
@@ -10,4 +10,25 @@ project:
 
 {% include stub %}
 
-Open Source APIs and Tools for teams competing in the FIRST Robotics Competition (FRC)
+[OpenRIO](https://github.com/Open-RIO) is an open source, collaborative organisation that provides APIs, Frameworks, Examples and other Software Utilities for FRC teams and members around the world. The organisation is best known for its work on the [Toast API](https://github.com/Open-RIO/ToastAPI) and [GradleRIO](https://github.com/Open-RIO/GradleRIO). Although in the early years of OpenRIO the Java programming language was primarily used, other languages such as C and C++ have also gained traction in future and existing projects.
+
+## Mission Statement
+OpenRIO carries the mission statement of "To provide accessible, free, intuitive software for anyone, anywhere, without the software being branded under any specific team number, therefore belonging to the community that builds it.". This statement entails that once a project is migrated to OpenRIO, it belongs to OpenRIO itself and the community, as the community of developers are major contributors to the success and stability of the project.
+
+## Origins and History
+In an attempt to improve code quality and bring the programming community of FRC together, OpenRIO was launched in 2015 by [Jaci R Brunning](https://github.com/JacisNonsense). The first projects of OpenRIO, the Toast API and its companion build system GradleRIO, were added to the organisation and refined to be ready to release. Both these projects started out as research projects of Jaci and later became staple projects of the organisation, gaining usage and modifications from teams and individuals across the globe.
+
+## Projects
+The most notable projects of OpenRIO are the Toast API and GradleRIO projects.  
+A full list of OpenRIO projects can be found on the [github organisation page](https://github.com/Open-RIO).
+
+### Toast API
+The [Toast API](https://github.com/Open-RIO/ToastAPI) (or simply *Toast*), started in late 2014 and migrated to OpenRIO in early 2015, is known for its innovative Module Loading and Simulation capabilities. Although Toast is written in the Java programming language, it has been hinted that a C++ version is in the works.
+
+### GradleRIO 
+The [GradleRIO](https://github.com/Open-RIO/GradleRIO) project was initially designed as a build system for Toast API and Toast Modules, although was later modified to work with any FRC Java project as an alternative build system to the WPILib ANT build system and eclipse plugins. GradleRIO was designed to be run from the command line, and bring the extensibility and flexibility of the Gradle build system to FRC, allowing for cross-platform builds and use of other IDEs apart from Eclipse, including IntelliJ IDEA.
+
+## Licensing
+As a rule-of-thumb, most of OpenRIOs projects are licensed under the MIT License for Open Source Software. For projects that use external projects with their own licenses, the external projects maintain their license. For example, the Toast API uses WPILib, and therefore the WPILib BSD License is maintained, while Toast itself uses the MIT License.
+
+It should be noted that projects that did not start out under OpenRIO may continue to maintain their original copyright and license holders. Most of these copyright holders are individuals, to avoid liability or conflict of interest issues associated with large collections of individuals (such as an FRC team).


### PR DESCRIPTION
Update the OpenRIO wiki entry to contain information about the organisation, mission statement, project (stub) entries, history and licensing.
