### PR TITLE
Update cim_motor.md

### DIFF
--- a/_tech/mechanical/motors/cim_motor.md
+++ b/_tech/mechanical/motors/cim_motor.md
@@ -12,9 +12,9 @@ Stall torque (in-lb) | 21.462
 Max power output (watts) | 337
 Free speed (rpm) | 5310
 
-One of the two basic [skid steer](skid-steer) [drive trains](drive-train) included in the [kit of parts](kit-of-parts) is designed to utilize one or two CIM motors on each side of the [robot](robot). This exact motor has been known over the years as the "CIM", "Chiaphua", or "Atwood" motor. The motor is provided in the kit of parts as part number "FR801-001". Some years have also shipped a larger three inch "Mini-bike" motor (part number FP801-005).
+One of the two basic [skid steer](skid-steer) [drive trains](drive-train) included in the [kit of parts](kit-of-parts) is designed to utilize one or two CIM motors on each side of the [robot](robot). This exact motor has been known over the years as the "CIM", "Chiaphua", or "Atwood" motor. The motor is provided in the kit of parts as part number "FR801-001". Some years (2006 & 2007) have also shipped a larger three inch "Mini-bike" motor (part number FP801-005).
 
-Exact specifications are available from FIRST: [FR801-001 MOTOR SPECIFICATIONS](http://www2.usfirst.org/2005comp/Specs/CIM.pdf "http://www2.usfirst.org/2005comp/Specs/CIM.pdf")
+Exact specifications are available from FIRST: [FR801-001 MOTOR SPECIFICATIONS](https://web.archive.org/web/20070203122606/http://www2.usfirst.org/2005comp/Specs/CIM.pdf "https://web.archive.org/web/20070203122606/http://www2.usfirst.org/2005comp/Specs/CIM.pdf")
 
 
 ## Torque and Efficiency curves
@@ -29,6 +29,22 @@ Stall          | 343.4          | 0           | 133.0       | 0          | 0%
 
 ## Kit of Parts
 
+### 2017
+
+CIM motors have been confirmed as legal in 2017 because they were available via FIRST Choice in round 1.
+
+### 2014-2016
+
+Four standard 2.5" motors are included, along with one miniCIM motor and one BAG motor.
+
+### 2013
+
+Two standard 2.5" motors are included, along with one miniCIM motor and one BAG motor.
+
+### 2012
+
+Two standard 2.5" motors are included.
+
 ### 2011
 
 Two standard 2.5" motors included, with AndyMark CIMple Box assembly. [[1]](ht
@@ -37,25 +53,29 @@ tp://usfirst.org/uploadedFiles/Robotics_Programs/FRC/Game_and_Season__Info/201
 //usfirst.org/uploadedFiles/Robotics_Programs/FRC/Game_and_Season__Info/2011_A
 ssets/Kit_of_Parts/2011%20Kit%20of%20Parts%20Checklist%20Rev%20E.pdf")
 
-### 2008
+### 2008-2010
 
-Two standard motors are included, 3.5" CIM no longer allowed.
+Two standard 2.5" motors are included, the 3" CIM is no longer legal.
 
 ### 2007
 
-Two of the standard 2.5" motors are included, and a larger 3.5" CIM.
+Two of the standard 2.5" motors are included, and a larger 3" CIM (previously labeled as mini-bike motors).
 
 ### 2006
 
-Two of the four CIM motors were replaced with the larger "mini-bike" motors. [[2]](http://www2.usfirst.org/2006comp/Manual/5-The_Robot_Rev_F.pdf "http://www2.usfirst.org/2006comp/Manual/5-The_Robot_Rev_F.pdf")
+Two of the four 2.5" CIM motors were replaced with two larger 3" "mini-bike" motors (labeled as 'Motor (Large)' in the KOP list). [[2]](https://web.archive.org/web/20060902090301/http://www2.usfirst.org/2006comp/Manual/5-The_Robot_Rev_F.pdf "https://web.archive.org/web/20060902090301/http://www2.usfirst.org/2006comp/Manual/5-The_Robot_Rev_F.pdf")
 
 ### 2005
 
-Four of the motors were included in the KOP.
+Four standard 2.5" motors are included in the KOP.
 
-### 2004
+### 2003 - 2004
 
-Two of the motors are included in the KOP.
+Two standard 2.5" motors are included in the KOP, now labeled as CIM Motors in the KOP list.
+
+### 2002
+
+CIM motors make their debut in FRC. Two 2.5" motors are provided in the KOP, labeled as Chiaphua Motors in the KOP list.
 
 ## Usage Notes
 


### PR DESCRIPTION
Added KOP data and changed links to archived versions when possible. Also, the 3" CIM was incorrectly identified as a 3.5" CIM.